### PR TITLE
feat: fall back to gh auth token when no explicit token is provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.direnv/
 /.pre-commit-config.yaml
+/result
 /target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.4.0-beta.1](https://github.com/EricCrosson/git-dl/compare/v1.3.1...v1.4.0-beta.1) (2026-05-12)
+
+
+### Features
+
+* fall back to gh auth token when no explicit token is provided ([1cd9570](https://github.com/EricCrosson/git-dl/commit/1cd9570e6565982d45253517c4f76ef23c9e6c31))
+
 ## [1.3.1](https://github.com/EricCrosson/git-dl/compare/v1.3.0...v1.3.1) (2026-03-16)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "git-dl"
-version = "1.3.1"
+version = "1.4.0-beta.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-dl"
-version = "1.3.1"
+version = "1.4.0-beta.1"
 edition = "2021"
 authors = ["Eric Crosson <eric.s.crosson@utexas.edu>"]
 license = "MIT OR Apache-2.0"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,6 +17,7 @@ Arguments:
 Options:
       --fork                         Create a fork of the target repository
       --github-token <GITHUB_TOKEN>  GitHub API token with `repo` permissions [env: GITHUB_TOKEN]
+                                     Falls back to `gh auth token` if not set
       --home <HOME>                  Location of the user's home directory [env: HOME]
   -h, --help                         Print help
   -V, --version                      Print version
@@ -28,8 +29,14 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub struct Args {
     pub repo: Repo,
     pub fork: bool,
-    pub github_token: String,
+    pub github_token: Option<String>,
     pub home: PathBuf,
+}
+
+fn token_from_args(args: &[String]) -> Option<String> {
+    args.windows(2)
+        .find(|w| w[0] == "--github-token" && !w[1].starts_with('-'))
+        .map(|w| w[1].clone())
 }
 
 impl Args {
@@ -71,9 +78,7 @@ impl Args {
             .map_err(|e| error::CliError::env_var_not_found(e))?
             .into();
 
-        // Get GITHUB_TOKEN from environment
-        let github_token =
-            env::var("GITHUB_TOKEN").map_err(|e| error::CliError::env_var_not_found(e))?;
+        let github_token = token_from_args(&args).or_else(|| env::var("GITHUB_TOKEN").ok());
 
         Ok(Args {
             repo,
@@ -91,7 +96,7 @@ mod tests {
             Ok(Self {
                 repo: repo_str.parse()?,
                 fork,
-                github_token: "test-token".to_string(),
+                github_token: Some("test-token".to_string()),
                 home: PathBuf::from("/home/test"),
             })
         }
@@ -104,7 +109,7 @@ mod tests {
         assert_eq!(args.repo.owner, "owner");
         assert_eq!(args.repo.name, "repo");
         assert!(!args.fork);
-        assert_eq!(args.github_token, "test-token");
+        assert_eq!(args.github_token, Some("test-token".to_string()));
         assert_eq!(args.home, PathBuf::from("/home/test"));
     }
 
@@ -119,5 +124,33 @@ mod tests {
     #[test]
     fn test_missing_repo() {
         assert!(Args::test_new("", false).is_err());
+    }
+
+    fn strs(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn token_from_args_returns_explicit_flag_value() {
+        let args = strs(&["git-dl", "owner/repo", "--github-token", "ghp_abc123"]);
+        assert_eq!(token_from_args(&args), Some("ghp_abc123".to_string()));
+    }
+
+    #[test]
+    fn token_from_args_returns_none_when_flag_absent() {
+        let args = strs(&["git-dl", "owner/repo"]);
+        assert_eq!(token_from_args(&args), None);
+    }
+
+    #[test]
+    fn token_from_args_returns_none_when_flag_at_end_with_no_value() {
+        let args = strs(&["git-dl", "owner/repo", "--github-token"]);
+        assert_eq!(token_from_args(&args), None);
+    }
+
+    #[test]
+    fn token_from_args_rejects_flag_as_token_value() {
+        let args = strs(&["git-dl", "owner/repo", "--github-token", "--fork"]);
+        assert_eq!(token_from_args(&args), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod git_interface;
 mod github_interface;
 mod little_anyhow;
 mod repo;
+mod token;
 
 use cli::Args;
 use git_interface::{git::SystemGit, GitOperations};
@@ -21,6 +22,11 @@ fn main() -> Result<(), little_anyhow::Error> {
         github_token,
         home,
     } = Args::parse()?;
+
+    let github_token = match github_token {
+        Some(t) => t,
+        None => token::resolve_token_from_gh_cli("github.com")?,
+    };
 
     let github = NativeGithubClient::new(github_token);
     let git = SystemGit::new();

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,115 @@
+use std::fmt::Display;
+use std::process::Command;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ResolveTokenError {
+    kind: ResolveTokenErrorKind,
+}
+
+#[derive(Debug)]
+enum ResolveTokenErrorKind {
+    Io(std::io::Error),
+    InvalidUtf8(std::string::FromUtf8Error),
+    NotFound,
+}
+
+impl ResolveTokenError {
+    fn io(err: std::io::Error) -> Self {
+        Self {
+            kind: ResolveTokenErrorKind::Io(err),
+        }
+    }
+
+    fn invalid_utf8(err: std::string::FromUtf8Error) -> Self {
+        Self {
+            kind: ResolveTokenErrorKind::InvalidUtf8(err),
+        }
+    }
+
+    fn not_found() -> Self {
+        Self {
+            kind: ResolveTokenErrorKind::NotFound,
+        }
+    }
+}
+
+impl Display for ResolveTokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "no GitHub token found; provide a token using one of these methods (in order of precedence):\n  \
+            1. --github-token <TOKEN>\n  \
+            2. GITHUB_TOKEN environment variable\n  \
+            3. Install and authenticate the GitHub CLI: gh auth login"
+        )
+    }
+}
+
+impl std::error::Error for ResolveTokenError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            ResolveTokenErrorKind::Io(err) => Some(err),
+            ResolveTokenErrorKind::InvalidUtf8(err) => Some(err),
+            ResolveTokenErrorKind::NotFound => None,
+        }
+    }
+}
+
+fn parse_gh_output(success: bool, stdout: Vec<u8>) -> Result<String, ResolveTokenError> {
+    if !success {
+        return Err(ResolveTokenError::not_found());
+    }
+
+    let token = String::from_utf8(stdout)
+        .map_err(ResolveTokenError::invalid_utf8)?
+        .trim()
+        .to_string();
+
+    if token.is_empty() {
+        return Err(ResolveTokenError::not_found());
+    }
+
+    Ok(token)
+}
+
+pub fn resolve_token_from_gh_cli(hostname: &str) -> Result<String, ResolveTokenError> {
+    let output = Command::new("gh")
+        .args(["auth", "token", "--hostname", hostname])
+        .output()
+        .map_err(ResolveTokenError::io)?;
+
+    parse_gh_output(output.status.success(), output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_gh_output_returns_trimmed_token() {
+        let result = parse_gh_output(true, b"ghp_abc123\n".to_vec());
+        assert_eq!(result.unwrap(), "ghp_abc123");
+    }
+
+    #[test]
+    fn parse_gh_output_trims_surrounding_whitespace() {
+        let result = parse_gh_output(true, b"  ghp_abc123  \n".to_vec());
+        assert_eq!(result.unwrap(), "ghp_abc123");
+    }
+
+    #[test]
+    fn parse_gh_output_errors_on_failed_status() {
+        assert!(parse_gh_output(false, b"ghp_abc123\n".to_vec()).is_err());
+    }
+
+    #[test]
+    fn parse_gh_output_errors_on_empty_stdout() {
+        assert!(parse_gh_output(true, b"".to_vec()).is_err());
+    }
+
+    #[test]
+    fn parse_gh_output_errors_on_whitespace_only_stdout() {
+        assert!(parse_gh_output(true, b"   \n".to_vec()).is_err());
+    }
+}


### PR DESCRIPTION
Token resolution now checks sources in order: \`--github-token\` flag, \`GITHUB_TOKEN\` env var, then \`gh auth token --hostname github.com\`. Users with the gh CLI authenticated no longer need to set \`GITHUB_TOKEN\` separately.

## Changes
- New \`src/token.rs\` with \`resolve_token_from_gh_cli\` and full test coverage
- \`Args.github_token\` is now \`Option\<String\>\`; resolved from flag/env, falls back to \`gh auth\`
- Guard against \`--github-token --flag\` (next arg is a flag, not a value)